### PR TITLE
Add apm.store_exceptions to disable logging of all thrown exceptions.

### DIFF
--- a/apm.ini
+++ b/apm.ini
@@ -1,5 +1,4 @@
 ; default configuration for php APM module
-
 extension=apm.so
 ; Whether the extension is globally active or not (overrides apm.event_enabled and apm.slow_request_enabled)
 ; apm.enabled="1"
@@ -22,6 +21,8 @@ extension=apm.so
 ; apm.store_cookies=On
 ; Boolean controlling whether the POST variables should be stored or not
 ; apm.store_post=On
+; Boolean controlling whether all exceptions thrown (caught or uncaught) should be stored or not
+; apm.store_exceptions=On
 ; Maximum recursion depth used when dumping a variable
 ; apm.dump_max_depth=4
 

--- a/php_apm.h
+++ b/php_apm.h
@@ -144,6 +144,8 @@ ZEND_BEGIN_MODULE_GLOBALS(apm)
 	zend_bool store_cookies;
 	/* Boolean controlling whether the POST variables should be generated or not */
 	zend_bool store_post;
+	/* Boolean controlling whether to log all exceptions thrown */
+	zend_bool store_exceptions;
 	/* Boolean controlling whether the processing of events by drivers should be deffered at the end of the request */
 	zend_bool deffered_processing;
 	/* Time (in ms) before a request is considered 'slow' */


### PR DESCRIPTION
- Add option apm.store_exceptions
- Don't log exceptions when apm.store_exceptions=Off
- Add APM_DEBUG() informing debuggers of this situation
