### PR TITLE
Call methods for protected PHP 7 exception properties

### DIFF
--- a/php_apm.h
+++ b/php_apm.h
@@ -45,6 +45,9 @@
 	#include <mysql/mysql.h>
 #endif
 
+#define phpext_apm_ptr &apm_module_entry
+extern zend_module_entry apm_module_entry;
+
 #ifdef PHP_WIN32
 #define PHP_APM_API __declspec(dllexport)
 #else


### PR DESCRIPTION
Accessing the properties directly causes errors in released version of PHP 7. Use the access methods instead. This also makes the zval handling in this function consistent with typical PHP 7 style.

This pull request also adds in the necessary pointer to include the extension with PHP 7 as part of a monolithic build.
