### PR TITLE
Update 2.1.3.pantheon3

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,9 @@
-APM 2.1.2        ?? ??? 2016
+APM 2.1.3        13 Feb 2017
+----------------------------
+Fixed:
+- PHP 5 build is broken #50 (Thanks Remi Collet)
+
+APM 2.1.2        13 Feb 2017
 ----------------------------
 Fixed:
 - Wrong path for mysql.h prevents Windows build

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ It doesn't require any modification to your application's code and let's you col
 1. `$ git clone https://github.com/patrickallaert/php-apm.git`
 2. `$ cd php-apm`
 3. `$ phpize`
-4. Configure the extension, by default, **sqlite3**, **MariaDB/MySQL**, **[StatsD](https://github.com/etsy/statsd/)** and **Socket** support are enabled:
+4. Configure the extension, by default, **sqlite3**, **MariaDB/MySQL**, **[StatsD](https://github.com/etsy/statsd/)**, **HTTP**, and **Socket** support are enabled:
 
     ```
-    $ ./configure [--with-sqlite3[=DIR]] [--with-mysql[=DIR]] [--enable-statsd] [--enable-socket] [--with-debugfile[=FILE]]
+    $ ./configure [--with-sqlite3[=DIR]] [--with-mysql[=DIR]] [--enable-statsd] [--enable-socket] [--enable-http] [--with-debugfile[=FILE]]
     ```
     To disable the support of a `--with-*` switch, use: `--without-*`, example: `$ ./configure --without-sqlite3`
     To disable the support of a `--enable-*` switch, use: `--disable-*`, example: `$ ./configure --disable-socket`

--- a/apm.c
+++ b/apm.c
@@ -156,10 +156,8 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("apm.application_id", "My application", PHP_INI_ALL, OnUpdateString, application_id, zend_apm_globals, apm_globals)
 	/* Boolean controlling whether the event monitoring is active or not */
 	STD_PHP_INI_BOOLEAN("apm.event_enabled", "1", PHP_INI_ALL, OnUpdateBool, event_enabled, zend_apm_globals, apm_globals)
-#if PHP_VERSION_ID < 70000
 	/* Boolean controlling whether the stacktrace should be stored or not */
 	STD_PHP_INI_BOOLEAN("apm.store_stacktrace", "1", PHP_INI_ALL, OnUpdateBool, store_stacktrace, zend_apm_globals, apm_globals)
-#endif
 	/* Boolean controlling whether the ip should be stored or not */
 	STD_PHP_INI_BOOLEAN("apm.store_ip", "1", PHP_INI_ALL, OnUpdateBool, store_ip, zend_apm_globals, apm_globals)
 	/* Boolean controlling whether the cookies should be stored or not */
@@ -554,12 +552,10 @@ static void process_event(int event_type, int type, char * error_filename, uint 
 	smart_str trace_str = {0};
 	apm_driver_entry * driver_entry;
 
-#if PHP_VERSION_ID < 70000
 	if (APM_G(store_stacktrace) && 0 == depth) {
 		append_backtrace(&trace_str TSRMLS_CC);
 		smart_str_0(&trace_str);
 	}
-#endif
 
 	driver_entry = APM_G(drivers);
 	APM_DEBUG("Direct processing process_event loop begin\n");
@@ -571,7 +567,7 @@ static void process_event(int event_type, int type, char * error_filename, uint 
 				error_lineno,
 				msg,
 #if PHP_VERSION_ID >= 70000
-				""
+				(APM_G(store_stacktrace) && trace_str.s && trace_str.s->val) ? trace_str.s->val : ""
 #else
 				(APM_G(store_stacktrace) && trace_str.c) ? trace_str.c : ""
 #endif

--- a/apm.ini
+++ b/apm.ini
@@ -97,3 +97,26 @@ extension=apm.so
 ; Socket path (accept multiple entries, separated by "|", prefixed with "file:" or "tcp:")
 ; Example: apm.socket_path=file:/var/tmp/apm.sock|tcp:localhost:1234
 ; apm.socket_path=file:/tmp/apm.sock
+
+; HTTP configuration
+; Whether to enable the HTTP driver
+; apm.http_enabled=On
+; Whether to collect stats for the HTTP driver
+; apm.http_stats_enabled=On
+; Error reporting level specific to the HTTP driver
+; apm.http_error_reporting=E_ALL|E_STRICT
+; Control which exceptions to collect (0: none exceptions collected, 1: collect uncaught exceptions (default), 2: collect ALL exceptions)
+; apm.http_exception_mode=1
+; Stores silenced events
+; apm.http_process_silenced_events = On
+; Server for POSTing events
+; apm.http_server=http://localhost
+; Client and certificate authority for making the server connection
+; apm.http_certificate_authorities=""
+; apm.http_client_certificate=""
+; apm.http_client_key=""
+; Maximum number of characters to include in backtrace (0=unlimited)
+; apm.http_max_backtrace_length=0
+; Timeout (in ms) for POSTing events
+; apm.http_request_timeout=1000
+

--- a/backtrace.c
+++ b/backtrace.c
@@ -378,11 +378,13 @@ static void append_flat_zval_r(zval *expr TSRMLS_DC, smart_str *trace_str, char 
 	}
 
 	switch (Z_TYPE_P(expr)) {
+#if PHP_VERSION_ID >= 70000
 		case IS_REFERENCE:
 			ZVAL_DEREF(expr);
 			smart_str_appendc(trace_str, '&');
 			append_flat_zval_r(expr, trace_str, depth);
 			break;
+#endif
 		case IS_ARRAY:
 			smart_str_appendc(trace_str, '[');
 #if PHP_VERSION_ID >= 70000

--- a/driver_http.c
+++ b/driver_http.c
@@ -1,0 +1,143 @@
+/*
+ +----------------------------------------------------------------------+
+ |  APM stands for Alternative PHP Monitor                              |
+ +----------------------------------------------------------------------+
+ | Copyright (c) 2011-2016  David Strauss                               |
+ +----------------------------------------------------------------------+
+ | This source file is subject to version 3.01 of the PHP license,      |
+ | that is bundled with this package in the file LICENSE, and is        |
+ | available through the world-wide-web at the following url:           |
+ | http://www.php.net/license/3_01.txt                                  |
+ | If you did not receive a copy of the PHP license and are unable to   |
+ | obtain it through the world-wide-web, please send a note to          |
+ | license@php.net so we can mail you a copy immediately.               |
+ +----------------------------------------------------------------------+
+ | Authors: David Strauss <david@davidstrauss.net>                      |
+ +----------------------------------------------------------------------+
+*/
+
+#include <stdio.h>
+#include <curl/curl.h>
+#include "php_apm.h"
+#include "php_ini.h"
+
+#include "driver_http.h"
+
+ZEND_EXTERN_MODULE_GLOBALS(apm)
+
+APM_DRIVER_CREATE(http)
+
+char *truncate_data(char *input_str, size_t max_len)
+{
+    char *truncated;
+    input_str = input_str ? input_str : NULL;
+    if (max_len == 0)
+        return strdup(input_str);
+    truncated = strndup(input_str, max_len);
+    return truncated;
+}
+
+/* Insert an event in the backend */
+void apm_driver_http_process_event(PROCESS_EVENT_ARGS)
+{
+  CURL *curl;
+  CURLcode res;
+
+  curl_global_init(CURL_GLOBAL_ALL);
+  curl = curl_easy_init();
+  if(curl) {
+    struct curl_httppost *formpost = NULL;
+    struct curl_httppost *lastptr = NULL;
+    struct curl_slist *headerlist = NULL;
+    static const char buf[] = "Expect:";
+    char int2string[64];
+    char *trace_to_send;
+    size_t max_len = 0;
+
+    if (APM_G(http_max_backtrace_length) >= 0)
+        max_len = APM_G(http_max_backtrace_length);
+
+    trace_to_send = truncate_data(trace, max_len);
+
+    sprintf(int2string, "%d", type);
+    curl_formadd(&formpost,
+             &lastptr,
+             CURLFORM_COPYNAME, "type",
+             CURLFORM_COPYCONTENTS, int2string,
+             CURLFORM_END);
+
+    curl_formadd(&formpost,
+             &lastptr,
+             CURLFORM_COPYNAME, "file",
+             CURLFORM_COPYCONTENTS, error_filename ? error_filename : "",
+             CURLFORM_END);
+
+    sprintf(int2string, "%d", error_lineno);
+    curl_formadd(&formpost,
+             &lastptr,
+             CURLFORM_COPYNAME, "line",
+             CURLFORM_COPYCONTENTS, int2string,
+             CURLFORM_END);
+
+    curl_formadd(&formpost,
+             &lastptr,
+             CURLFORM_COPYNAME, "message",
+             CURLFORM_COPYCONTENTS, msg ? msg : "",
+             CURLFORM_END);
+
+    curl_formadd(&formpost,
+             &lastptr,
+             CURLFORM_COPYNAME, "backtrace",
+             CURLFORM_COPYCONTENTS, trace_to_send,
+             CURLFORM_END);
+    
+    headerlist = curl_slist_append(headerlist, buf);
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headerlist);
+    curl_easy_setopt(curl, CURLOPT_HTTPPOST, formpost);
+
+    curl_easy_setopt(curl, CURLOPT_URL, APM_G(http_server));
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, APM_G(http_request_timeout));
+    if (APM_G(http_client_certificate) != NULL) {
+      curl_easy_setopt(curl, CURLOPT_SSLCERT, APM_G(http_client_certificate));
+    }
+    if (APM_G(http_client_key) != NULL) {
+      curl_easy_setopt(curl, CURLOPT_SSLKEY, APM_G(http_client_key));
+    }
+    if (APM_G(http_certificate_authorities) != NULL) {
+      curl_easy_setopt(curl, CURLOPT_CAINFO, APM_G(http_certificate_authorities));
+      curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
+    }
+    
+    res = curl_easy_perform(curl);
+ 
+    APM_DEBUG("[HTTP driver] Result: %s\n", curl_easy_strerror(res));
+
+    /* Always clean up. */
+    curl_easy_cleanup(curl);
+    free(trace_to_send);
+  }
+}
+
+int apm_driver_http_minit(int module_number)
+{
+	return SUCCESS;
+}
+
+int apm_driver_http_rinit()
+{
+	return SUCCESS;
+}
+
+int apm_driver_http_mshutdown()
+{
+	return SUCCESS;
+}
+
+int apm_driver_http_rshutdown()
+{
+	return SUCCESS;
+}
+
+void apm_driver_http_process_stats(TSRMLS_D)
+{
+}

--- a/driver_http.h
+++ b/driver_http.h
@@ -1,0 +1,30 @@
+/*
+ +----------------------------------------------------------------------+
+ |  APM stands for Alternative PHP Monitor                              |
+ +----------------------------------------------------------------------+
+ | Copyright (c) 2011-2016  David Strauss                                |
+ +----------------------------------------------------------------------+
+ | This source file is subject to version 3.01 of the PHP license,      |
+ | that is bundled with this package in the file LICENSE, and is        |
+ | available through the world-wide-web at the following url:           |
+ | http://www.php.net/license/3_01.txt                                  |
+ | If you did not receive a copy of the PHP license and are unable to   |
+ | obtain it through the world-wide-web, please send a note to          |
+ | license@php.net so we can mail you a copy immediately.               |
+ +----------------------------------------------------------------------+
+ | Authors: David Strauss <david@davidstrauss.net>                      |
+ +----------------------------------------------------------------------+
+*/
+
+#ifndef DRIVER_HTTP_H
+#define DRIVER_HTTP_H
+
+#include "zend_API.h"
+
+#define APM_E_http APM_E_ALL
+
+apm_driver_entry * apm_driver_http_create();
+
+PHP_INI_MH(OnUpdateAPMhttpErrorReporting);
+
+#endif

--- a/package.xml
+++ b/package.xml
@@ -103,6 +103,9 @@ Fixed:
    <notes>
 Fixed:
 - Wrong path for mysql.h prevents Windows build
+- Possible segmentation fault and invalid errors under PHP 7.0
+- Make error: duplicate symbol for architecture x86_64 #25
+- Build with PHP 7.1 #44 (Thanks Remi Collet)
    </notes>
   </release>
   <release>

--- a/package.xml
+++ b/package.xml
@@ -32,7 +32,7 @@ A web frontend exists for manipulating the data stored in database at: https://g
  </lead>
  <date>2017-02-13</date>
  <version>
-  <release>2.1.2</release>
+  <release>2.1.3</release>
   <api>2.0.0</api>
  </version>
  <stability>
@@ -42,10 +42,7 @@ A web frontend exists for manipulating the data stored in database at: https://g
  <license uri="http://www.php.net/license">PHP License</license>
  <notes>
 Fixed:
-- Wrong path for mysql.h prevents Windows build
-- Possible segmentation fault and invalid errors under PHP 7.0
-- Make error: duplicate symbol for architecture x86_64 #25
-- Build with PHP 7.1 #44 (Thanks Remi Collet)
+- PHP 5 build is broken #50 (Thanks Remi Collet)
  </notes>
  <contents>
   <dir name="/">
@@ -89,6 +86,22 @@ Fixed:
   <configureoption name="enable-statsd" default="yes" prompt="Enable Statsd support"/>
  </extsrcrelease>
  <changelog>
+  <release>
+   <version>
+    <release>2.1.3</release>
+    <api>2.0.0</api>
+   </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
+   <date>2017-02-13</date>
+   <license uri="http://www.php.net/license">PHP License</license>
+   <notes>
+Fixed:
+- PHP 5 build is broken #50 (Thanks Remi Collet)
+   </notes>
+  </release>
   <release>
    <version>
     <release>2.1.2</release>

--- a/package.xml
+++ b/package.xml
@@ -32,7 +32,7 @@ A web frontend exists for manipulating the data stored in database at: https://g
  </lead>
  <date>2016-03-29</date>
  <version>
-  <release>2.1.1</release>
+  <release>2.1.1.pantheon2</release>
   <api>2.0.0</api>
  </version>
  <stability>

--- a/package.xml
+++ b/package.xml
@@ -32,7 +32,7 @@ A web frontend exists for manipulating the data stored in database at: https://g
  </lead>
  <date>2017-02-13</date>
  <version>
-  <release>2.1.3.pantheon2</release>
+  <release>2.1.3.pantheon3</release>
   <api>2.0.0</api>
  </version>
  <stability>

--- a/php_apm.h
+++ b/php_apm.h
@@ -328,9 +328,9 @@ ZEND_BEGIN_MODULE_GLOBALS(apm)
 	zend_bool socket_enabled;
 	/* Boolean controlling the collection of stats */
 	zend_bool socket_stats_enabled;
-	/* (unused for StatsD) */
+	/* (unused for socket) */
 	long socket_exception_mode;
-	/* (unused for StatsD) */
+	/* (unused for socket) */
 	int socket_error_reporting;
 	/* Option to process silenced events */
 	zend_bool socket_process_silenced_events;
@@ -339,6 +339,27 @@ ZEND_BEGIN_MODULE_GLOBALS(apm)
 	apm_event_entry *socket_events;
 	apm_event_entry **socket_last_event;
 #endif
+
+#ifdef APM_DRIVER_HTTP
+	/* Boolean controlling whether the driver is active or not */
+	zend_bool http_enabled;
+	/* Boolean controlling the collection of stats */
+	zend_bool http_stats_enabled;
+	/* (unused for HTTP) */
+	long http_exception_mode;
+	/* (unused for HTTP) */
+	int http_error_reporting;
+	/* Option to process silenced events */
+	zend_bool http_process_silenced_events;
+
+	long http_request_timeout;
+	char *http_server;
+	char *http_client_certificate;
+	char *http_client_key;
+	char *http_certificate_authorities;
+	long http_max_backtrace_length;
+#endif
+
 ZEND_END_MODULE_GLOBALS(apm)
 
 #ifdef ZTS

--- a/php_apm.h
+++ b/php_apm.h
@@ -19,7 +19,7 @@
 #ifndef PHP_APM_H
 #define PHP_APM_H
 
-#define PHP_APM_VERSION "2.1.3.pantheon2"
+#define PHP_APM_VERSION "2.1.3.pantheon3"
 
 #ifdef HAVE_CONFIG_H
 # include "config.h"

--- a/php_apm.h
+++ b/php_apm.h
@@ -19,7 +19,7 @@
 #ifndef PHP_APM_H
 #define PHP_APM_H
 
-#define PHP_APM_VERSION "2.1.1"
+#define PHP_APM_VERSION "2.1.1.pantheon2"
 
 #ifdef HAVE_CONFIG_H
 # include "config.h"

--- a/php_apm.h
+++ b/php_apm.h
@@ -19,7 +19,7 @@
 #ifndef PHP_APM_H
 #define PHP_APM_H
 
-#define PHP_APM_VERSION "2.1.2"
+#define PHP_APM_VERSION "2.1.3"
 
 #ifdef HAVE_CONFIG_H
 # include "config.h"

--- a/php_apm.h
+++ b/php_apm.h
@@ -45,6 +45,9 @@
 	#include <mysql/mysql.h>
 #endif
 
+#define phpext_apm_ptr &apm_module_entry
+extern zend_module_entry apm_module_entry;
+
 #ifdef PHP_WIN32
 #define PHP_APM_API __declspec(dllexport)
 #else


### PR DESCRIPTION
Per https://github.com/pantheon-systems/php-apm/pull/2: Remove Pantheon customizations ('depth' variable and php7 checks to disable stacktrace operations.)