### PR TITLE
Php7.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ mkinstalldirs
 modules/
 run-tests.php
 *.lo
+/apm.ini.*
+/config.log
+/configure.ac

--- a/backtrace.c
+++ b/backtrace.c
@@ -387,29 +387,29 @@ static void append_flat_zval_r(zval *expr TSRMLS_DC, smart_str *trace_str, char 
 #endif
 		case IS_ARRAY:
 			smart_str_appendc(trace_str, '[');
-#if PHP_VERSION_ID >= 70000
-			if (ZEND_HASH_APPLY_PROTECTION(Z_ARRVAL_P(expr)) && ++Z_ARRVAL_P(expr)->u.v.nApplyCount>1) {
-#else
-			if (++Z_ARRVAL_P(expr)->nApplyCount>1) {
-#endif
-				smart_str_appendl(trace_str, " *RECURSION*", sizeof(" *RECURSION*") - 1);
-#if PHP_VERSION_ID >= 70000
-				Z_ARRVAL_P(expr)->u.v.nApplyCount--;
-#else
-				Z_ARRVAL_P(expr)->nApplyCount--;
-#endif
-				return;
-			}
+// #if PHP_VERSION_ID >= 70000
+// 			if (ZEND_HASH_APPLY_PROTECTION(Z_ARRVAL_P(expr)) && ++Z_ARRVAL_P(expr)->u.v.nApplyCount>1) {
+// #else
+// 			if (++Z_ARRVAL_P(expr)->nApplyCount>1) {
+// #endif
+// 				smart_str_appendl(trace_str, " *RECURSION*", sizeof(" *RECURSION*") - 1);
+// #if PHP_VERSION_ID >= 70000
+// 				Z_ARRVAL_P(expr)->u.v.nApplyCount--;
+// #else
+// 				Z_ARRVAL_P(expr)->nApplyCount--;
+// #endif
+// 				return;
+// 			}
 			append_flat_hash(Z_ARRVAL_P(expr) TSRMLS_CC, trace_str, 0, depth + 1);
 			smart_str_appendc(trace_str, ']');
-#if PHP_VERSION_ID >= 70000
-			if (ZEND_HASH_APPLY_PROTECTION(Z_ARRVAL_P(expr))) {
-				Z_ARRVAL_P(expr)->u.v.nApplyCount--;
-			}
-#else
-			Z_ARRVAL_P(expr)->nApplyCount--;
-#endif
-			break;
+// #if PHP_VERSION_ID >= 70000
+// 			if (ZEND_HASH_APPLY_PROTECTION(Z_ARRVAL_P(expr))) {
+// 				Z_ARRVAL_P(expr)->u.v.nApplyCount--;
+// 			}
+// #else
+// 			Z_ARRVAL_P(expr)->nApplyCount--;
+// #endif
+//			break;
 		case IS_OBJECT:
 		{
 			HashTable *properties = NULL;
@@ -419,10 +419,10 @@ static void append_flat_zval_r(zval *expr TSRMLS_DC, smart_str *trace_str, char 
 			smart_str_appendl(trace_str, " Object (", sizeof(" Object (") - 1);
 			zend_string_release(class_name);
 
-			if (Z_OBJ_APPLY_COUNT_P(expr) > 0) {
-				smart_str_appendl(trace_str, " *RECURSION*", sizeof(" *RECURSION*") - 1);
-				return;
-			}
+			// if (Z_OBJ_APPLY_COUNT_P(expr) > 0) {
+			// 	smart_str_appendl(trace_str, " *RECURSION*", sizeof(" *RECURSION*") - 1);
+			// 	return;
+			// }
 #else
 			char *class_name = NULL;
 			zend_uint clen;
@@ -443,21 +443,21 @@ static void append_flat_zval_r(zval *expr TSRMLS_DC, smart_str *trace_str, char 
 				properties = Z_OBJPROP_P(expr);
 			}
 			if (properties) {
-#if PHP_VERSION_ID >= 70000
-				Z_OBJ_INC_APPLY_COUNT_P(expr);
-#else
-				if (++properties->nApplyCount>1) {
-					smart_str_appendl(trace_str, " *RECURSION*", sizeof(" *RECURSION*") - 1);
-					properties->nApplyCount--;
-					return;
-				}
-#endif
+// #if PHP_VERSION_ID >= 70000
+// 				Z_OBJ_INC_APPLY_COUNT_P(expr);
+// #else
+// 				if (++properties->nApplyCount>1) {
+// 					smart_str_appendl(trace_str, " *RECURSION*", sizeof(" *RECURSION*") - 1);
+// 					properties->nApplyCount--;
+// 					return;
+// 				}
+// #endif
 				append_flat_hash(properties TSRMLS_CC, trace_str, 1, depth + 1);
-#if PHP_VERSION_ID >= 70000
-				Z_OBJ_DEC_APPLY_COUNT_P(expr);
-#else
-				properties->nApplyCount--;
-#endif
+// #if PHP_VERSION_ID >= 70000
+// 				Z_OBJ_DEC_APPLY_COUNT_P(expr);
+// #else
+// 				properties->nApplyCount--;
+// #endif
 			}
 			smart_str_appendc(trace_str, ')');
 			break;

--- a/backtrace.c
+++ b/backtrace.c
@@ -392,7 +392,7 @@ static void append_flat_zval_r(zval *expr TSRMLS_DC, smart_str *trace_str, char 
 // #else
 // 			if (++Z_ARRVAL_P(expr)->nApplyCount>1) {
 // #endif
-// 				smart_str_appendl(trace_str, " *RECURSION*", sizeof(" *RECURSION*") - 1);
+			// smart_str_appendl(trace_str, " *RECURSION*", sizeof(" *RECURSION*") - 1);
 // #if PHP_VERSION_ID >= 70000
 // 				Z_ARRVAL_P(expr)->u.v.nApplyCount--;
 // #else
@@ -409,7 +409,7 @@ static void append_flat_zval_r(zval *expr TSRMLS_DC, smart_str *trace_str, char 
 // #else
 // 			Z_ARRVAL_P(expr)->nApplyCount--;
 // #endif
-//			break;
+			break;
 		case IS_OBJECT:
 		{
 			HashTable *properties = NULL;

--- a/backtrace.c
+++ b/backtrace.c
@@ -29,6 +29,8 @@
 
 ZEND_DECLARE_MODULE_GLOBALS(apm);
 
+inline static zend_bool php_apm_zend_hash_apply_protection_begin(HashTable* ht);
+inline static zend_bool php_apm_zend_hash_apply_protection_end(HashTable* ht)
 static void debug_print_backtrace_args(zval *arg_array TSRMLS_DC, smart_str *trace_str);
 static void append_flat_zval_r(zval *expr TSRMLS_DC, smart_str *trace_str, char depth);
 static void append_flat_hash(HashTable *ht TSRMLS_DC, smart_str *trace_str, char is_object, char depth);
@@ -46,7 +48,7 @@ static char *apm_addslashes(char *str, uint length, int *new_length);
 #ifdef ZEND_HASH_GET_APPLY_COUNT /* PHP 7.2 or earlier recursion protection */
 
 
-inline static zend_bool php_apm_zend_hash_apply_protection(HashTable* ht)
+inline static zend_bool php_apm_zend_hash_apply_protection_begin(HashTable* ht)
 {
 	if (!ht) {
 		return 1;

--- a/backtrace.c
+++ b/backtrace.c
@@ -30,7 +30,7 @@
 ZEND_DECLARE_MODULE_GLOBALS(apm);
 
 inline static zend_bool php_apm_zend_hash_apply_protection_begin(HashTable* ht);
-inline static zend_bool php_apm_zend_hash_apply_protection_end(HashTable* ht)
+inline static zend_bool php_apm_zend_hash_apply_protection_end(HashTable* ht);
 static void debug_print_backtrace_args(zval *arg_array TSRMLS_DC, smart_str *trace_str);
 static void append_flat_zval_r(zval *expr TSRMLS_DC, smart_str *trace_str, char depth);
 static void append_flat_hash(HashTable *ht TSRMLS_DC, smart_str *trace_str, char is_object, char depth);


### PR DESCRIPTION
ZEND_HASH_APPLY_PROTECTION and nApplyCount member are deprecated in php 7.3.  

> From UPGRADING.INTERNALS

  c. Protection from recursion during processing circular data structures was
     refactored. HashTable.nApplyCount and IS_OBJ_APPLY_COUNT are replaced by
     single flag GC_PROTECTED. Corresponding macros Z_OBJ_APPLY_COUNT,
     Z_OBJ_INC_APPLY_COUNT, Z_OBJ_DEC_APPLY_COUNT, ZEND_HASH_GET_APPLY_COUNT,
     ZEND_HASH_INC_APPLY_COUNT, ZEND_HASH_DEC_APPLY_COUNT are replaced with
     GC_IS_RECURSIVE, GC_PROTECT_RECURSION, GC_UNPROTECT_RECURSION,
     Z_IS_RECURSIVE, Z_PROTECT_RECURSION, Z_UNPROTECT_RECURSION.

     HASH_FLAG_APPLY_PROTECTION flag and ZEND_HASH_APPLY_PROTECTION() macro
     are removed. All mutable arrays should use recursion protection.
     Corresponding checks should be replaced by Z_REFCOUNTED() or
     !(GC_GLAGS(p) & GC_IMMUTABLE).


> Found excellent examples here:  https://news-web.php.net/php.cvs/99639

I'm new to PHP internals, but thought I'd take a crack at this as I need to get it working with php7.3.  It seems to have compiled, tested successfully, and is working correctly in the dev environment.  I stumbled upon the inline hash protection function idea from PHP Mongo development team.  
https://github.com/mongodb/mongo-php-driver/commit/197f3f7a8a73391cbe489bc900b9f1f1d47d3341

Also, a sincere thank you.  This project is really a huge help. Impressive work! 
DV
